### PR TITLE
Allow `reconfigure` default port value to 11434

### DIFF
--- a/GhidrOllama.py
+++ b/GhidrOllama.py
@@ -182,8 +182,8 @@ class Config:
         except CancelledException:
             return False
         print("Selected port: " + str(port))
-        if port == None:
-            return False
+        if port == 0 or port == None:
+            return 11434
 
         # Get scheme
         monitor.setMessage("Waiting for model select...")


### PR DESCRIPTION
Updates the default port for reconfigure to 11434 for a better user experience.